### PR TITLE
[R] parse_args now requests 6 arguments.

### DIFF
--- a/R/graphical_output.R
+++ b/R/graphical_output.R
@@ -11,7 +11,7 @@ pkload("optparse")
 
 parser_object <- OptionParser(usage = "Usage: %prog [Working directory] [occurences.sgc.txt] [polygons.sgc.txt] [sampletable.sgc.txt] [speciestable.sgc.txt]", 
                               description="")
-opti <- parse_args(parser_object, args = commandArgs(trailingOnly = TRUE), positional_arguments = 5)
+opti <- parse_args(parser_object, args = commandArgs(trailingOnly = TRUE), positional_arguments = 6)
 
 #__ GUI STUFF
 source(paste(opti$args[1],"/R/SpeciesGeoCodeR.R",sep=""))


### PR DESCRIPTION
Previously the parse_args function requested 5 arguments instead of the
6 that were actually used.